### PR TITLE
Bugfix: Fix `.avif` files handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export default function mysongCompress(options: CompressionOptions = {}): AstroI
             if (/\.(jpe?g|png|webp|tiff?|avif|heif)$/i.test(filePath)) {
                 let pipeline = sharp(filePath);
                 const format = (await pipeline.metadata()).format;
+                const compression = (await pipeline.metadata()).compression;
                 logger.debug("Format: " + format);
 
                 const formatConfig = {
@@ -102,7 +103,7 @@ export default function mysongCompress(options: CompressionOptions = {}): AstroI
                     jpeg: () => pipeline.jpeg(compressionConfig.jpeg),
                     webp: () => pipeline.webp(compressionConfig.webp),
                     avif: () => pipeline.avif(compressionConfig.avif),
-                    heif: () => pipeline.heif(compressionConfig.heif)
+                    heif: () => pipeline.heif({...compressionConfig.heif, compression})
                 };
 
                 if (format && format in formatConfig) {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,17 +1,17 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-import mysongCompress from '../src/index';
-import { setupTestFiles, getFileSize } from './helpers';
+import type { AstroIntegrationLogger } from 'astro';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import type { AstroIntegrationLogger } from 'astro';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { defaultCacheDir } from '../src/defaultConfig';
+import mysongCompress from '../src/index';
+import { setupTestFiles } from './helpers';
 
 describe('Cache System', () => {
   let tempDir: string;
 
   const TEST_FILES = {
     css: {
-      path: 'style.css',
+      name: 'style.css',
       content: `
         .container {
           padding: 20px   20px   20px   20px;
@@ -21,7 +21,7 @@ describe('Cache System', () => {
       `
     },
     js: {
-      path: 'script.js',
+      name: 'script.js',
       content: `
         // This comment should be removed
         function test() {
@@ -48,13 +48,12 @@ describe('Cache System', () => {
     }
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     tempDir = path.join(__dirname, 'fixtures', 'temp-cache-' + Date.now());
-    await fs.mkdir(tempDir, { recursive: true });
     await setupTestFiles(tempDir, TEST_FILES);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -121,8 +120,8 @@ describe('Cache System', () => {
   }
 
   test('should cache compressed files', async () => {
-    const cssPath = path.join(tempDir, TEST_FILES.css.path);
-    const jsPath = path.join(tempDir, TEST_FILES.js.path);
+    const cssPath = path.join(tempDir, TEST_FILES.css.name);
+    const jsPath = path.join(tempDir, TEST_FILES.js.name);
     
     
     const beforeRunCssStats = await fs.stat(cssPath);
@@ -152,7 +151,7 @@ describe('Cache System', () => {
   });
 
   test('should invalidate cache when file content changes', async () => {
-    const cssPath = path.join(tempDir, TEST_FILES.css.path);
+    const cssPath = path.join(tempDir, TEST_FILES.css.name);
     
     // First compression run
     const compress1 = mysongCompress();
@@ -177,7 +176,7 @@ describe('Cache System', () => {
   });
 
   test('should invalidate cache when compression settings change', async () => {
-    const jsPath = path.join(tempDir, TEST_FILES.js.path);
+    const jsPath = path.join(tempDir, TEST_FILES.js.name);
     
     const originalContent = await fs.readFile(jsPath);
     // First compression run with default settings

--- a/test/css.test.ts
+++ b/test/css.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import mysongCompress from '../src/index';
-import { setupTestFiles, getFileSize } from './helpers';
+import { setupTestFiles, getFileSize, setupTestFile } from './helpers';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { AstroIntegrationLogger } from 'astro';
@@ -10,7 +10,7 @@ describe('CSS Compression', () => {
 
   const TEST_CSS = {
     basic: {
-      path: 'basic.css',
+      name: 'basic.css',
       content: `
         .container {
           padding: 20px   20px   20px   20px;  /* Should be simplified */
@@ -30,7 +30,7 @@ describe('CSS Compression', () => {
       `
     },
     withVendorPrefixes: {
-      path: 'prefixes.css',
+      name: 'prefixes.css',
       content: `
         .box {
           -webkit-border-radius: 10px;
@@ -134,7 +134,7 @@ describe('CSS Compression', () => {
   }
 
   test('should minify basic CSS', async () => {
-    const filePath = path.join(tempDir, TEST_CSS.basic.path);
+    const filePath = path.join(tempDir, TEST_CSS.basic.name);
     const originalSize = await getFileSize(filePath);
     
     const compress = mysongCompress();
@@ -157,7 +157,7 @@ describe('CSS Compression', () => {
   });
 
   test('should handle vendor prefixes', async () => {
-    const filePath = path.join(tempDir, TEST_CSS.withVendorPrefixes.path);
+    const filePath = path.join(tempDir, TEST_CSS.withVendorPrefixes.name);
     const originalSize = await getFileSize(filePath);
     
     const compress = mysongCompress();
@@ -180,7 +180,7 @@ describe('CSS Compression', () => {
 
   test('should handle malformed CSS gracefully', async () => {
     const malformedCSS = {
-      path: 'malformed.css',
+      name: 'malformed.css',
       content: `
         / .broken {
           color: red  /* Missing closing brace */
@@ -189,8 +189,7 @@ describe('CSS Compression', () => {
       `
     };
 
-    await setupTestFiles(tempDir, { malformed: malformedCSS });
-    const filePath = path.join(tempDir, malformedCSS.path);
+    const filePath = await setupTestFile(tempDir, malformedCSS);
     const originalContent = await fs.readFile(filePath, 'utf-8');
     
     const compress = mysongCompress();
@@ -203,7 +202,6 @@ describe('CSS Compression', () => {
     expect(exists).toBe(true);
     
     const finalContent = await fs.readFile(filePath, 'utf-8');
-    console.log(finalContent);
     expect(finalContent).toBe(originalContent);
   });
 }); 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,12 +1,20 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-export async function setupTestFiles(tempDir: string, files: Record<string, any>) {
-  for (const [type, fileInfo] of Object.entries(files)) {
-    const filePath = path.join(tempDir, fileInfo.path);
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, fileInfo.content);
-  }
+type Data = Parameters<typeof fs.writeFile>[1];
+export type TestFileConfig = { name: string, content: Data }
+
+export async function setupTestFiles(tempDir: string, files: Record<string, TestFileConfig>) {
+  await Promise.all(Object.values(files).map(fileInfo =>
+    setupTestFile(tempDir, fileInfo)
+  ));
+}
+
+export async function setupTestFile(tempDir: string, fileInfo: TestFileConfig) {
+  await fs.mkdir(tempDir, { recursive: true });  
+  const filePath = path.join(tempDir, fileInfo.name);
+  await fs.writeFile(filePath, fileInfo.content);
+  return filePath;
 }
 
 export async function getFileSize(filePath: string): Promise<number> {


### PR DESCRIPTION
Solves issue #7

## Changes:
 - **fix `.avif` files**: correctly handles `compression` _option_ for `heif()`
 - **refactor tests**: previously each test unit **created all files** inside `fixtures/temp-*` (instead of only the file(s) from the test itself), consequently a test unit would process files from another tests, causing errors in some cases.